### PR TITLE
ci: fail post-deploy health check when backend API is down

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,8 @@ jobs:
   # Backend -> GHCR Docker image
   # ---------------------------------------------------------------------------
   deploy-backend:
-    name: Deploy Backend (Docker)
+    # Only builds and pushes the image to GHCR; the Railway service that runs it is dashboard-managed.
+    name: Publish Backend Image (Docker)
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.manual == 'true'

--- a/.github/workflows/post-deploy-health-check.yml
+++ b/.github/workflows/post-deploy-health-check.yml
@@ -64,3 +64,39 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT: ${{ secrets.VERCEL_PROJECT_ID }}
         run: bash scripts/post_deploy_health_check.sh
+
+      - name: Check backend API health
+        shell: bash
+        env:
+          APP_URL: https://blog-ai.vivancedata.com
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+        run: |
+          set -euo pipefail
+          api="${API_BASE_URL:-}"
+          if [ -z "$api" ]; then
+            # Fall back to whatever backend the deployed site is allowed to call (CSP connect-src).
+            api="$(curl -sSI "$APP_URL/" \
+              | grep -i '^content-security-policy:' \
+              | grep -oE 'connect-src[^;]*' \
+              | grep -oE 'https://[^ ]*railway\.app' | head -n1 || true)"
+            if [ -z "$api" ]; then
+              echo "::error::Could not resolve API base URL: vars.API_BASE_URL is unset and no railway.app host found in $APP_URL CSP connect-src."
+              exit 1
+            fi
+            echo "Resolved API base URL from CSP connect-src: $api"
+          else
+            echo "Using API base URL from vars.API_BASE_URL: $api"
+          fi
+          api="${api%/}"
+          host="${api#*://}"
+          for attempt in 1 2 3; do
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$api/health" || echo 000)"
+            if [ "$code" = "200" ]; then
+              echo "Backend $host is healthy (GET /health -> 200)."
+              exit 0
+            fi
+            echo "Attempt $attempt/3: GET $api/health -> HTTP $code"
+            [ "$attempt" -lt 3 ] && sleep 10
+          done
+          echo "::error::Backend $host is DOWN: GET $api/health did not return 200 after 3 attempts (last: HTTP $code)."
+          exit 1


### PR DESCRIPTION
## What changed
- `post-deploy-health-check.yml`: new step **Check backend API health**. Resolves the API base URL from repo variable `vars.API_BASE_URL`, falling back to the `railway.app` host in the deployed site's `Content-Security-Policy` `connect-src` header (currently `https://backend-production-10b3.up.railway.app`). Fails the job unless `GET $API/health` returns 200 within 3 attempts (10s apart), printing an `::error::` naming the host.
- `deploy.yml`: job renamed `Deploy Backend (Docker)` -> `Publish Backend Image (Docker)` (it only pushes to GHCR) with a comment noting the Railway service is dashboard-managed.

## Verification
- `python yaml.safe_load` on both workflows: OK.
- Ran the new step's shell locally against the real site:
```
Resolved API base URL from CSP connect-src: https://backend-production-10b3.up.railway.app
Attempt 1/3: GET https://backend-production-10b3.up.railway.app/health -> HTTP 404
...
::error::Backend backend-production-10b3.up.railway.app is DOWN: GET .../health did not return 200 after 3 attempts (last: HTTP 404).
exit=1
```
So the hourly check will now go red until the backend is restored (it is currently down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWPUnp8TJdNp6q9CphFDM