### PR TITLE
chore(deploy): add railway.json for backend service

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.backend"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}


### PR DESCRIPTION
Adds `railway.json` (DOCKERFILE builder, `dockerfilePath: Dockerfile.backend`, `/health` healthcheck) so `railway up` on the `backend` service builds the API image.

Verified: `railway up --detach --service backend` picks up the config and starts uploading; the upload is currently rejected by Railway with "Your trial has expired. Please select a plan" — a billing decision, not a repo issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWPUnp8TJdNp6q9CphFDM