### PR TITLE
fix(ui): stop the auth proxy swallowing the public /tools pages, and keep the hero CTA visible

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { motion, useInView } from 'framer-motion'
 import SiteHeader from '../components/SiteHeader'
 import SiteFooter from '../components/SiteFooter'
-import { SignedIn, SignedOut } from '../lib/clerk-ui'
+import { useAuth } from '../lib/clerk-ui'
 import { TOOL_CATEGORIES } from '../types/tools'
 import {
   SparklesIcon,
@@ -52,6 +52,16 @@ function RevealSection({ children, className = '' }: RevealSectionProps) {
 
 export default function Home(): React.ReactElement {
   const isClerkConfigured = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  const { isLoaded, isSignedIn } = useAuth()
+
+  // Render the signed-out CTA until Clerk positively reports a session.
+  // Clerk's <SignedIn>/<SignedOut> BOTH render nothing while clerk.browser.js
+  // is still loading — and forever if it fails to load — which left the hero
+  // with a subhead, an empty gap, and a "No credit card required" line
+  // pointing at no button. The primary action must not depend on a
+  // third-party script being reachable.
+  const showSignedInCta = isClerkConfigured && isLoaded && isSignedIn
+  const startFreeHref = isClerkConfigured ? '/sign-up' : '/auth'
 
   return (
     <>
@@ -115,43 +125,26 @@ export default function Home(): React.ReactElement {
                 transition={{ duration: 0.5 }}
                 className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
-                {isClerkConfigured ? (
+                {showSignedInCta ? (
                   <>
-                    <SignedOut>
-                      <Link
-                        href="/sign-up"
-                        className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-xl transition-colors shadow-sm shadow-amber-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
-                      >
-                        Start Free
-                        <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-                      </Link>
-                      <Link
-                        href="/pricing"
-                        className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-gray-700 dark:text-gray-300 bg-white/70 dark:bg-gray-900/60 border border-black/[0.08] dark:border-white/[0.08] hover:border-black/[0.12] dark:hover:border-white/[0.12] hover:bg-white/90 dark:hover:bg-gray-800/70 rounded-xl backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
-                      >
-                        View Plans
-                      </Link>
-                    </SignedOut>
-                    <SignedIn>
-                      <Link
-                        href="/generate"
-                        className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-xl transition-colors shadow-sm shadow-amber-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
-                      >
-                        Start Generating
-                        <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-                      </Link>
-                      <Link
-                        href="/brand"
-                        className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-gray-700 dark:text-gray-300 bg-white/70 dark:bg-gray-900/60 border border-black/[0.08] dark:border-white/[0.08] hover:border-black/[0.12] dark:hover:border-white/[0.12] hover:bg-white/90 dark:hover:bg-gray-800/70 rounded-xl backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
-                      >
-                        Open Brand Voice
-                      </Link>
-                    </SignedIn>
+                    <Link
+                      href="/generate"
+                      className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-xl transition-colors shadow-sm shadow-amber-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+                    >
+                      Start Generating
+                      <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+                    </Link>
+                    <Link
+                      href="/brand"
+                      className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-gray-700 dark:text-gray-300 bg-white/70 dark:bg-gray-900/60 border border-black/[0.08] dark:border-white/[0.08] hover:border-black/[0.12] dark:hover:border-white/[0.12] hover:bg-white/90 dark:hover:bg-gray-800/70 rounded-xl backdrop-blur-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+                    >
+                      Open Brand Voice
+                    </Link>
                   </>
                 ) : (
                   <>
                     <Link
-                      href="/auth"
+                      href={startFreeHref}
                       className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-xl transition-colors shadow-sm shadow-amber-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
                     >
                       Start Free
@@ -333,30 +326,17 @@ export default function Home(): React.ReactElement {
               faster, more consistent SEO content production.
             </p>
             <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-              {isClerkConfigured ? (
-                <>
-                  <SignedOut>
-                    <Link
-                      href="/sign-up"
-                      className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-amber-700 bg-white hover:bg-amber-50 rounded-lg transition-colors shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600"
-                    >
-                      Start Free
-                      <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-                    </Link>
-                  </SignedOut>
-                  <SignedIn>
-                    <Link
-                      href="/generate"
-                      className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-amber-700 bg-white hover:bg-amber-50 rounded-lg transition-colors shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600"
-                    >
-                      Start Generating
-                      <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-                    </Link>
-                  </SignedIn>
-                </>
+              {showSignedInCta ? (
+                <Link
+                  href="/generate"
+                  className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-amber-700 bg-white hover:bg-amber-50 rounded-lg transition-colors shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600"
+                >
+                  Start Generating
+                  <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+                </Link>
               ) : (
                 <Link
-                  href="/auth"
+                  href={startFreeHref}
                   className="inline-flex items-center gap-2 px-7 py-3.5 text-base font-medium text-amber-700 bg-white hover:bg-amber-50 rounded-lg transition-colors shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600"
                 >
                   Start Free

--- a/apps/web/app/tools/page.tsx
+++ b/apps/web/app/tools/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next'
-import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { getClerkUserIdOrNull } from '../../lib/clerk-auth'
 import ToolsPageClient from './ToolsPageClient'
 
 export const metadata: Metadata = {
@@ -10,11 +8,11 @@ export const metadata: Metadata = {
     'Browse AI writing tools by category and launch purpose-built workflows for blogs, email, social, and more.',
 }
 
-export default async function ToolsPage() {
-  const userId = await getClerkUserIdOrNull()
-  if (!userId) {
-    redirect('/sign-in')
-  }
+// Public marketing/SEO page: it is listed in app/sitemap.ts, linked from
+// SiteFooter and /tool-directory, and renders entirely from the bundled
+// SAMPLE_TOOLS catalogue with no authenticated request. Signing in is only
+// required to open an individual tool workspace at /tools/[slug].
+export default function ToolsPage() {
   return (
     <Suspense fallback={<div className="p-8 text-center text-sm text-gray-500">Loading tools...</div>}>
       <ToolsPageClient />

--- a/apps/web/e2e/protected-routes.spec.ts
+++ b/apps/web/e2e/protected-routes.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test'
 import { resolveProtectedRouteState } from './helpers'
 
 /**
- * E2E smoke tests for protected routes (templates, remix, onboarding, tools).
+ * E2E smoke tests for protected routes (templates, remix, onboarding, tool
+ * workspace).
  *
  * These routes require authentication. Without valid credentials the server
  * redirects to sign-in. We verify the route either renders the protected
@@ -42,14 +43,16 @@ test.describe('Protected Routes', () => {
     expect(['protected', 'auth']).toContain(state)
   })
 
-  test('tools route responds and redirects to auth or renders', async ({
+  // `/tools` itself and `/tools/category/[category]` are PUBLIC (see
+  // tool-directory.spec.ts). Only the per-tool workspace needs a session.
+  test('tool workspace route responds and redirects to auth or renders', async ({
     page,
   }) => {
-    const response = await page.goto('/tools')
+    const response = await page.goto('/tools/blog-title-generator')
 
     expect(response?.status()).toBeLessThan(500)
 
-    const state = await resolveProtectedRouteState(page, /\/tools/)
+    const state = await resolveProtectedRouteState(page, /\/tools\/blog-title-generator/)
     expect(['protected', 'auth']).toContain(state)
   })
 

--- a/apps/web/e2e/tool-directory.spec.ts
+++ b/apps/web/e2e/tool-directory.spec.ts
@@ -51,4 +51,28 @@ test.describe('Tool Directory', () => {
     await expect(page.getByRole('banner')).toBeVisible()
     await expect(page.getByRole('contentinfo')).toBeVisible()
   })
+
+  test('interactive tools page is public and renders its catalogue', async ({
+    page,
+  }) => {
+    await page.goto('/tools')
+
+    // Staying on the requested path is the assertion that matters: a
+    // protected route would have been redirected away by proxy.ts.
+    expect(new URL(page.url()).pathname).toBe('/tools')
+    await expect(page.locator('body')).toContainText(/AI Writing Tools/i)
+    await expect(page.getByRole('contentinfo')).toBeVisible()
+  })
+
+  test('tool category page is public and renders its category', async ({
+    page,
+  }) => {
+    await page.goto('/tools/category/seo')
+
+    expect(new URL(page.url()).pathname).toBe('/tools/category/seo')
+    await expect(page.locator('body')).toContainText(/SEO Tools/i)
+    await expect(
+      page.getByRole('link', { name: /Back to directory/i })
+    ).toBeVisible()
+  })
 })

--- a/apps/web/lib/protected-routes.ts
+++ b/apps/web/lib/protected-routes.ts
@@ -1,0 +1,40 @@
+/**
+ * Route patterns that require an authenticated session.
+ *
+ * These are consumed by `proxy.ts` (the Next 16 name for `middleware.ts`) via
+ * Clerk's `createRouteMatcher`, which matches each pattern against the request
+ * pathname: RegExp entries are used directly with `RegExp.prototype.test`,
+ * string entries are compiled with path-to-regexp.
+ *
+ * The list lives in its own module so it can be unit-tested without importing
+ * `proxy.ts` (which pulls in `@clerk/nextjs/server` and the Next runtime).
+ *
+ * Rule of thumb when adding an entry: a prefix pattern such as `/foo(.*)`
+ * swallows *every* route under `/foo`, including public marketing pages. Check
+ * `app/sitemap.ts` before adding one.
+ */
+export const PROTECTED_ROUTE_PATTERNS: (string | RegExp)[] = [
+  '/history(.*)',
+  '/brand(.*)',
+  '/admin(.*)',
+  '/bulk(.*)',
+  '/remix(.*)',
+  '/analytics(.*)',
+  // `/tools` (the browsable tool listing) and `/tools/category/[category]`
+  // are PUBLIC marketing/SEO surfaces: they render SiteHeader/SiteFooter, fall
+  // back to SAMPLE_TOOLS without any authenticated request, and are advertised
+  // in `app/sitemap.ts`. Only the per-tool workspace at `/tools/[slug]` — which
+  // generates content, writes history and reads brand profiles — needs a
+  // session. A blanket `/tools(.*)` swallowed all three and 307'd the public
+  // pages to the Clerk sign-in host.
+  /^\/tools\/(?!category(?:\/|$))[^/]+/,
+  '/templates(.*)',
+  '/onboarding(.*)',
+  '/plagiarism(.*)',
+  '/images(.*)',
+  '/settings(.*)',
+  '/social(.*)',
+  '/generate(.*)',
+  '/knowledge(.*)',
+  '/team(.*)',
+]

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,24 +1,8 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server'
+import { PROTECTED_ROUTE_PATTERNS } from './lib/protected-routes'
 
-const isProtectedRoute = createRouteMatcher([
-  '/history(.*)',
-  '/brand(.*)',
-  '/admin(.*)',
-  '/bulk(.*)',
-  '/remix(.*)',
-  '/analytics(.*)',
-  '/tools(.*)',
-  '/templates(.*)',
-  '/onboarding(.*)',
-  '/plagiarism(.*)',
-  '/images(.*)',
-  '/settings(.*)',
-  '/social(.*)',
-  '/generate(.*)',
-  '/knowledge(.*)',
-  '/team(.*)',
-])
+const isProtectedRoute = createRouteMatcher(PROTECTED_ROUTE_PATTERNS)
 
 const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 const clerkDomain = process.env.NEXT_PUBLIC_CLERK_DOMAIN?.trim() || ''

--- a/apps/web/tests/app/HomePageClient.test.tsx
+++ b/apps/web/tests/app/HomePageClient.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '../../hooks/useTheme'
+import Home from '../../app/HomePageClient'
+
+/**
+ * The hero CTA must never disappear.
+ *
+ * Clerk's <SignedIn>/<SignedOut> both render nothing until clerk.browser.js has
+ * loaded — and forever if it fails to load (a blocked script, a misconfigured
+ * custom domain). That left the homepage with a headline, a subhead, an empty
+ * gap where the buttons belong, and a "No credit card required" line pointing
+ * at nothing. These tests pin the unauthenticated CTA to the "not yet loaded"
+ * state so the primary action never depends on a third-party script.
+ */
+const authState = {
+  isLoaded: false,
+  isSignedIn: false,
+  userId: null as string | null,
+}
+
+vi.mock('../../lib/clerk-ui', () => ({
+  isClerkConfigured: () => true,
+  useAuth: () => authState,
+  // SiteHeader/SiteFooter render inside the page; mirror Clerk's real
+  // behaviour, where both gates render nothing until the script has loaded.
+  SignedIn: () => null,
+  SignedOut: () => null,
+  UserButton: () => null,
+}))
+
+function renderHome() {
+  return render(<Home />, { wrapper: ThemeProvider })
+}
+
+const originalClerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_dummy'
+
+  if (!('IntersectionObserver' in globalThis)) {
+    class MockIntersectionObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): [] {
+        return []
+      }
+    }
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      writable: true,
+      value: MockIntersectionObserver,
+    })
+  }
+})
+
+afterAll(() => {
+  if (originalClerkKey) {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = originalClerkKey
+  } else {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  }
+})
+
+beforeEach(() => {
+  authState.isLoaded = false
+  authState.isSignedIn = false
+  authState.userId = null
+})
+
+describe('HomePageClient hero CTA', () => {
+  it('renders the signed-out CTA while Clerk is still loading', () => {
+    renderHome()
+
+    const startFree = screen.getAllByRole('link', { name: /start free/i })
+    expect(startFree.length).toBeGreaterThan(0)
+    expect(startFree[0]).toHaveAttribute('href', '/sign-up')
+    expect(screen.getByRole('link', { name: /view plans/i })).toHaveAttribute(
+      'href',
+      '/pricing'
+    )
+  })
+
+  it('still renders the signed-out CTA when Clerk loads with no session', () => {
+    authState.isLoaded = true
+
+    renderHome()
+
+    expect(screen.getByRole('link', { name: /view plans/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /start generating/i })).toBeNull()
+  })
+
+  it('swaps to the authenticated CTA once Clerk reports a session', () => {
+    authState.isLoaded = true
+    authState.isSignedIn = true
+    authState.userId = 'user_test'
+
+    renderHome()
+
+    expect(
+      screen.getAllByRole('link', { name: /start generating/i })[0]
+    ).toHaveAttribute('href', '/generate')
+    // "View Plans" is unique to the signed-out hero (the pricing section keeps
+    // its own "Start Free" tier button, so that label is not a hero signal).
+    expect(screen.queryByRole('link', { name: /view plans/i })).toBeNull()
+  })
+})

--- a/apps/web/tests/lib/protected-routes.test.ts
+++ b/apps/web/tests/lib/protected-routes.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { createPathMatcher } from '@clerk/shared/pathMatcher'
+import { PROTECTED_ROUTE_PATTERNS } from '../../lib/protected-routes'
+
+/**
+ * `proxy.ts` feeds PROTECTED_ROUTE_PATTERNS to Clerk's `createRouteMatcher`,
+ * which is a thin wrapper over `createPathMatcher(patterns)(req.nextUrl.pathname)`.
+ * Matching the pathname through the same engine here means this test exercises
+ * the real matching semantics, not a re-implementation of them.
+ */
+const isProtected = createPathMatcher(PROTECTED_ROUTE_PATTERNS)
+
+describe('protected route matcher', () => {
+  it.each([
+    '/tools',
+    '/tools/category/seo',
+    '/tools/category/social-media',
+    '/tools/category',
+    '/tool-directory',
+    '/',
+    '/pricing',
+    '/blog',
+    '/blog/some-post',
+    '/sign-in',
+    '/sign-up',
+  ])('leaves the public route %s unprotected', (pathname) => {
+    expect(isProtected(pathname)).toBe(false)
+  })
+
+  it.each([
+    '/admin',
+    '/admin/blog',
+    '/history',
+    '/brand',
+    '/brand/train',
+    '/bulk',
+    '/remix',
+    '/analytics',
+    '/templates',
+    '/onboarding',
+    '/plagiarism',
+    '/images',
+    '/settings/webhooks',
+    '/social',
+    '/generate',
+    '/knowledge',
+    '/team',
+    // The per-tool workspace still requires a session.
+    '/tools/blog-title-generator',
+    '/tools/blog-title-generator/edit',
+  ])('protects %s', (pathname) => {
+    expect(isProtected(pathname)).toBe(true)
+  })
+
+  it('does not let a "category"-prefixed slug slip past the workspace gate', () => {
+    // Only the real /tools/category/* subtree is public; a tool whose slug
+    // merely starts with "category" must stay protected.
+    expect(isProtected('/tools/categoryzer')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What was broken

Four public marketing routes returned a 307 to a dead auth host instead of their content:

```
$ curl -sI -H 'Sec-Fetch-Dest: document' https://blog-ai.vivancedata.com/tools/category/seo
HTTP/2 307
location: https://accounts.lscaturchio.xyz/sign-in?redirect_url=...
x-clerk-auth-reason: session-token-and-uat-missing
```

`/tools` and `/tools/category/[category]` both did this. `/tool-directory` was fine only
because its path string happens not to start with `tools`.

Separately, the homepage hero rendered **no CTA at all**: headline, subhead, an empty gap,
and then "No credit card required. Start free…" pointing at nothing.

## Root cause

**1. The route matcher.** In Next 16 `middleware.ts` is named `proxy.ts`, which is why
grepping for middleware finds nothing. `apps/web/proxy.ts:11` listed `'/tools(.*)'` among the
protected routes, and that pattern matches *every* path under `/tools` — including the public
listing at `app/tools/page.tsx` and the SEO category pages at
`app/tools/category/[category]/page.tsx`. Those pages render `SiteHeader`/`SiteFooter`, fall
back to the bundled `SAMPLE_TOOLS` with no authenticated request, call `notFound()`, link
"Back to directory", and are advertised in `app/sitemap.ts`. `app/tools/page.tsx` also carried
its own `redirect('/sign-in')` guard, so removing the matcher entry alone would not have
unblocked it.

**2. The hero CTA.** `apps/web/app/HomePageClient.tsx:118-167` gated both CTA variants on
Clerk's `<SignedOut>`/`<SignedIn>`. Those components render `null` until `clerk.browser.js`
has loaded — and forever if it never loads. The trust line at line 176 stayed put, so the hero
advertised a free tier with no way to start it.

## The fix

- `apps/web/lib/protected-routes.ts` (new) holds the matcher patterns, so the list is
  unit-testable without importing `proxy.ts` (and its `@clerk/nextjs/server` dependency).
  `'/tools(.*)'` becomes `/^\/tools\/(?!category(?:\/|$))[^/]+/`: the per-tool workspace at
  `/tools/[slug]` — which generates content, writes history and reads brand profiles — still
  needs a session; `/tools` and `/tools/category/*` do not.
- `apps/web/app/tools/page.tsx` drops its page-level `redirect('/sign-in')`. It renders
  entirely from `SAMPLE_TOOLS`; nothing on it requires a user.
- `apps/web/app/HomePageClient.tsx` computes `showSignedInCta = isClerkConfigured && isLoaded
  && isSignedIn` from the repo's existing `useAuth()` wrapper and renders the signed-out CTA in
  every other state. Fixed at the component layer rather than by preloading Clerk, because the
  page's primary action must not depend on a third-party script being reachable at all. The
  same treatment is applied to the duplicate final-CTA block. No new markup, colours or
  spacing — the existing button classes are reused verbatim.

**Audit of every other matcher entry.** Each of `/history`, `/brand`, `/admin`, `/bulk`,
`/remix`, `/analytics`, `/templates`, `/onboarding`, `/plagiarism`, `/images`, `/settings`,
`/social`, `/generate`, `/knowledge`, `/team` was checked against `app/`: every one maps only
to app pages that already call `getClerkUserIdOrNull()` and redirect, and every one is marked
`authRequired: true` in `components/SiteHeader.tsx`. None of them shares a prefix with a public
route (`/blog`, `/pricing`, `/privacy`, `/terms`, `/rss`, `/tool-directory`, `/sign-in`,
`/sign-up`, `/auth`). `/tools` was the only collision. `/images(.*)` looks risky but `public/`
holds no `images/` directory, and the `config.matcher` in `proxy.ts` already excludes
extensioned files.

## Verification

Reproducing production exactly needs a configured Clerk instance, so the app was built and
started with live-format keys pointing at an unreachable domain — this yields the same
`x-clerk-auth-reason: session-token-and-uat-missing` as the live 307 above.

```
$ bun install && bun run build          # apps/web, Compiled successfully in 10.3s
$ bun run lint && bun run type-check    # clean
$ PORT=3311 bun run start
$ for p in ... ; do curl -sI -H 'Sec-Fetch-Dest: document' localhost:3311$p ; done
/                                200
/tools                           200
/tools/category/seo              200
/tool-directory                  200
/tools/blog-title-generator      307 -> https://accounts.example.com/sign-in?redirect_url=...
/admin/blog                      307 -> https://accounts.example.com/sign-in?redirect_url=...
/generate                        307 -> https://accounts.example.com/sign-in?redirect_url=...
```

Public pages serve content; the tool workspace and the genuinely protected areas still
redirect.

```
$ bunx vitest run
Test Files  20 passed (20)
     Tests  237 passed (237)

$ bunx playwright test e2e/tool-directory.spec.ts e2e/protected-routes.spec.ts
14 passed (41.3s)
```

Both new test files were confirmed to fail against the pre-fix code, not just pass against the
new code:

- `tests/lib/protected-routes.test.ts` — 31 cases through Clerk's own `createPathMatcher`
  (the exact engine `createRouteMatcher` wraps), asserting `/tools/category/seo` and `/tools`
  are public while `/admin`, `/generate`, `/tools/blog-title-generator` and the rest are not.
  Against the old list: `OLD /tools true`, `OLD /tools/category/seo true`.
- `tests/app/HomePageClient.test.tsx` — 3 cases pinning the CTA across
  `isLoaded:false` / loaded-signed-out / loaded-signed-in. Against the old component all three
  fail with `Unable to find an accessible element with the role "link" and name /view plans/i`,
  which is precisely the buttonless hero.

Screenshots (desktop 1440x1600 and mobile 390x844, light and dark, with all requests to the
Clerk domain aborted so the failure mode is reproduced) are in
`scratchpad/uiaudit/after/blog-AI/`: the hero shows "Start Free" + "View Plans" with Clerk
unreachable, `/tools` renders the 29-tool catalogue with filters, and `/tools/category/seo`
renders "SEO Tools" with its cards and "Back to directory" link in both themes.

## Required follow-up this repo cannot do — Cloudflare DNS

`accounts.lscaturchio.xyz` and `clerk.lscaturchio.xyz` are Clerk custom domains read from
`NEXT_PUBLIC_CLERK_DOMAIN` (not hardcoded anywhere). Their CNAMEs are correct, but the records
are **Cloudflare-proxied (orange cloud)** while Clerk already sits behind Cloudflare —
Cloudflare proxying Cloudflare produces Error 1000. Fix in the Cloudflare dashboard by setting
`accounts`, `clerk`, `clkmail`, `clk._domainkey` and `clk2._domainkey` to **DNS only (grey
cloud)**. The homepage's 12 console errors have the same single root cause (failed
`clerk.browser.js` loads plus retried `/v1/client` and `/v1/environment` calls) and will clear
with it. This PR does not touch DNS; it makes the marketing surface and the hero CTA survive
that outage instead of depending on it.

## Not covered

- **`/tools/[slug]` stays protected**, in both the matcher and its own page guard. It is the
  authenticated generation workspace (writes history, reads brand profiles and LLM config) and
  its metadata is a generic "Tool Workspace" rather than per-tool SEO copy. Opening it is a
  product decision, not a bug fix.
- **`app/sitemap.ts` still advertises `/tools/{slug}` and `/templates`**, both of which require
  a session. That is a real SEO inconsistency, but resolving it means deciding whether those
  pages should be public — the same product call as above — so it is left alone here.
- `components/SiteHeader.tsx` still lists Tools under `authRequired: true`, so the now-public
  listing is only linked from `SiteFooter` and `/tool-directory` for signed-out visitors. Left
  as-is to keep this diff to the defect; flipping it is a nav decision.
- No DNS, backend or dependency changes. PR #157's files are untouched.
