### PR TITLE
content: draft post on AI content and plagiarism checking

### DIFF
--- a/content/drafts/ai-content-plagiarism-check.md
+++ b/content/drafts/ai-content-plagiarism-check.md
@@ -1,0 +1,44 @@
+---
+title: Does AI-Generated Content Count as Plagiarism? How to Check Before You Publish
+date: 2026-09-03
+excerpt: What plagiarism actually means for AI-written text, the two ways it shows up, and how to check a draft before it goes live.
+slug: ai-content-plagiarism-check
+tags: [plagiarism, ai-writing, seo, content-ops]
+draft: true
+---
+
+## Why the question comes up
+
+The most common objection to AI-assisted writing isn't quality anymore — it's originality. Teams that were fine with AI drafts for internal notes get nervous the moment a post is headed to a public URL with the company's name on it, because a plagiarism flag after publish is expensive to fix: rewrite the piece, lose whatever search ranking it had built, and explain to whoever asked "wasn't this AI-checked?"
+
+The honest answer is that AI-generated text isn't plagiarism by default, but it isn't automatically safe either. It depends on what the model leaned on to write the sentence in front of you, and that's exactly the thing you can't tell just by reading the draft.
+
+## Two ways a draft can fail the check
+
+**Verbatim overlap.** A source article gets quoted or paraphrased closely enough that a chunk of the draft matches existing text word-for-word or near enough to trip a similarity threshold. This is more likely when a topic has one or two canonical explanations online and the model's phrasing converges on the same wording everyone else already used.
+
+**Derivative sameness.** No single source matches, but the structure, examples, and conclusions are close enough to an existing piece that it reads as a rewrite rather than original analysis. This one doesn't show up in a similarity score at all — it's a judgment call a human still has to make.
+
+A plagiarism checker only catches the first kind. That's a real limit, not a flaw in the tooling, and it's why a passing score is a gate, not a guarantee.
+
+## How the check works
+
+Running a draft through /plagiarism sends it to a provider — Copyscape or Originality.ai, whichever is configured — that searches for matching text across the web and returns matched sources with a similarity percentage for each. If neither provider is available, it falls back to an embedding-based similarity check run locally, which is less precise but catches the obvious cases without an external API call.
+
+Either way, the result is a score, not a pass/fail. Risk buckets from none (under 5% similarity) up through critical (50%+) tell you how much of the draft to scrutinize before deciding: skim the flagged sentences at low risk, read the matched sources side-by-side at moderate risk, and treat critical as "rewrite the section, don't just reword it."
+
+## Where this fits before you publish
+
+Plagiarism and fact-checking solve different problems and belong at different points in the workflow. Fact-checking (built into /generate) verifies that a claim is *true* against the sources it was researched from. A plagiarism check verifies that the *wording* is yours, independent of whether the claim is accurate. A draft can pass one and fail the other — a perfectly true sentence can still be lifted almost verbatim from the source that supplied the fact.
+
+Run the plagiarism check last, after any edits, since editing is exactly what changes the similarity score. A check run before the final pass tells you about a draft that no longer exists.
+
+## A pre-publish checklist
+
+- Run the draft through /plagiarism after your last edit, not before it.
+- Anything in the moderate bucket or higher: open the matched source and compare side-by-side, don't just reword the flagged sentence.
+- Treat a clean score as "no verbatim overlap found," not "this is original analysis" — that second judgment is still yours to make.
+- For a topic with few authoritative sources (regulatory text, a single vendor's documentation), expect a higher baseline similarity and budget more time for the moderate-risk review.
+- Keep the matched-source list from a critical flag; if you rewrite around a study or dataset, you'll want the citation anyway.
+
+None of this replaces editorial judgment — it just gives you a score to react to instead of a hunch. Check /pricing for which plan includes plagiarism checking, and /tools for where it sits alongside fact-checking and SEO scoring in the rest of the pipeline.


### PR DESCRIPTION
## Summary
- New draft blog post: `content/drafts/ai-content-plagiarism-check.md`
- Kept as `draft: true` under `content/drafts/` — not read by `loadBlogPosts()` (which only scans `content/blog/`), so it does not appear on `/blog`, in the sitemap, or in the DB-backed post list until a human moves/publishes it.

## Why this draft, why now
Search intent: "does AI-generated content count as plagiarism" / "AI content plagiarism checker" — one of the most common pre-purchase objections for an AI writing tool, and one the site didn't yet have a post addressing. It maps directly to the existing `/plagiarism` feature (Copyscape / Originality.ai / embedding-based fallback, per `apps/api/src/quality/plagiarism_checker.py`) and distinguishes it from the separate fact-checking feature in `/generate`, since those get conflated by prospective users.

Voice and frontmatter schema (title/date/excerpt/slug/tags/draft) were matched against the one existing draft, `content/drafts/keep-ai-content-on-brand.md`.

## Verification
- Frontmatter parses correctly against the app's own `parseFrontmatter` logic in `apps/web/lib/blog-index.ts` (checked directly, not just by inspection).
- `bun run lint` — clean.
- `bun run build` — succeeds (Next.js 16 / Turbopack), all 36 routes build.
- No code changes — content-only addition under `content/drafts/`.

## Test plan
- [ ] Read the draft for voice/accuracy fit
- [ ] Move to `content/blog/` (dropping `draft: true`) when ready to publish, or request edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQukMRXJT49Kv2KBqeGJc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQukMRXJT49Kv2KBqeGJc9)_

---
verified: CI green as of 2026-09-15 (all reported checks passing); awaiting human review, no code changes since last CI run.

---
_Generated by [Claude Code](https://claude.ai/code)_